### PR TITLE
refactor: cache inode->pid lookup via map on function startup

### DIFF
--- a/linux-open-ports.go
+++ b/linux-open-ports.go
@@ -12,7 +12,7 @@ import (
 type OpenPort struct {
 	Protocol string
 	Port     int
-	PID      int
+	PID      string
 }
 
 func GetOpenPorts() ([]OpenPort, error) {


### PR DESCRIPTION
this pr makes the above change to omit the lookup of the pid via the inode by iterating all /proc/<pid>/fd directories